### PR TITLE
fix: treat non-finite altitudes as unknown in flight timeout helpers

### DIFF
--- a/src/flight_timeout_utils.py
+++ b/src/flight_timeout_utils.py
@@ -15,9 +15,17 @@ from src.params import Params
 
 def _coerce_non_negative_altitude(relative_altitude_m) -> float | None:
     try:
-        return max(0.0, float(relative_altitude_m))
+        altitude_m = float(relative_altitude_m)
     except (TypeError, ValueError):
         return None
+
+    # NaN / ±inf are not credible altitude telemetry. Treat them like parse
+    # failures so callers use the intentional minimum-wait defaults instead of
+    # letting max(0.0, nan) collapse to 0.0 and quietly inflate the budget.
+    if not math.isfinite(altitude_m):
+        return None
+
+    return max(0.0, altitude_m)
 
 
 def calculate_land_disarm_timeout(relative_altitude_m, *, params=Params) -> int:

--- a/tests/test_flight_timeout_utils.py
+++ b/tests/test_flight_timeout_utils.py
@@ -1,8 +1,23 @@
+import math
+
 from src import flight_timeout_utils as timeouts
 
 
 def test_calculate_land_disarm_timeout_defaults_to_minimum_when_altitude_unknown():
     assert timeouts.calculate_land_disarm_timeout(None) == timeouts.Params.LAND_ACTION_MIN_DISARM_WAIT_SEC
+
+
+def test_coerce_non_negative_altitude_rejects_non_finite_values():
+    assert timeouts._coerce_non_negative_altitude(math.nan) is None
+    assert timeouts._coerce_non_negative_altitude(math.inf) is None
+    assert timeouts._coerce_non_negative_altitude(-math.inf) is None
+
+
+def test_calculate_land_disarm_timeout_defaults_to_minimum_for_non_finite_altitude():
+    minimum = timeouts.Params.LAND_ACTION_MIN_DISARM_WAIT_SEC
+    assert timeouts.calculate_land_disarm_timeout(math.nan) == minimum
+    assert timeouts.calculate_land_disarm_timeout(math.inf) == minimum
+    assert timeouts.calculate_land_disarm_timeout(-math.inf) == minimum
 
 
 def test_calculate_land_disarm_timeout_scales_with_altitude_and_respects_cap():


### PR DESCRIPTION
## Summary
`_coerce_non_negative_altitude` now requires `math.isfinite` after a successful `float()` conversion. NaN/`±inf` return `None` so land/disarm and dependent RTL timeout helpers follow the same unknown altitude → minimum wait path already used for `None`/unparseable input.

## Motivation
With IEEE NaN, `max(0.0, float('nan'))` is `0.0` in Python. That made broken altitude telemetry look like on-the-ground zero and still applied buffer math, producing a non-minimum wait budget with false confidence.

## Changes
- src/flight_timeout_utils.py — finite check before non-negative clamp
- tests/test_flight_timeout_utils.py — unit coverage for nan/inf

## Verification
pytest tests/test_flight_timeout_utils.py -q --noconftest (6 passed)

## Notes
No Params / arm / geofence changes.
