### PR TITLE
fix: treat non-finite values as conversion failures in safe_float

### DIFF
--- a/functions/data_utils.py
+++ b/functions/data_utils.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 
 def safe_int(value, default=0):
@@ -15,7 +16,13 @@ def safe_float(value, default=0.0):
         if value is None:
             logging.warning(f"Expected float, got None. Using default {default}.")
             return default
-        return float(value)
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            logging.error(
+                f"Non-finite float value {value!r}. Using default {default}."
+            )
+            return default
+        return parsed
     except (ValueError, TypeError) as e:
         logging.error(f"Error converting value to float: {e}. Using default {default}.")
         return default

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -101,6 +101,16 @@ class TestSafeFloat:
         assert safe_float([1.0, 2.0]) == 0.0
         assert safe_float({'key': 1.5}) == 0.0
 
+    def test_nonfinite_returns_default(self):
+        """Non-finite values must not masquerade as valid telemetry numbers."""
+        import math
+        from functions.data_utils import safe_float
+
+        assert safe_float(math.nan) == 0.0
+        assert safe_float(float("nan"), default=1.5) == 1.5
+        assert safe_float(math.inf) == 0.0
+        assert safe_float(-math.inf, default=-1.0) == -1.0
+
 
 class TestSafeGet:
     """Test safe_get function"""


### PR DESCRIPTION
## Summary
- Make `safe_float` reject NaN / ±inf (return the caller default), same class of failures as TypeError/ValueError.
- Add unit coverage for non-finite inputs in `tests/test_data_utils.py`.

## Motivation
`float('nan')` / `math.inf` succeed at conversion today, but downstream code often assumes a finite scalar for timeouts, altitudes, and packing. Align with existing `_finite_float` / WGS84 finite checks so poison telemetry does not look numeric.

## Verification
- Offline checks of `safe_float` finite + non-finite paths (full pytest suite needs pyproj; module under test is pure).

## Safety
- Fail-closed only; no geofence/arm/params changes.
