### PR TITLE
fix: validate finite WGS84 lat/lon/alt in origin cache load/save

### DIFF
--- a/src/origin_cache.py
+++ b/src/origin_cache.py
@@ -27,6 +27,7 @@ Version: 3.8 (Phase 2)
 """
 
 import json
+import math
 import os
 from datetime import datetime
 from pathlib import Path
@@ -39,6 +40,23 @@ CACHE_DIR = Path.home() / '.mavsdk_drone_show'
 CACHE_FILE = CACHE_DIR / 'origin_cache.json'
 
 logger = get_logger("origin_cache")
+
+
+def _validate_origin_coords(origin_data) -> bool:
+    """Return True if lat/lon/alt are finite floats in WGS84-usable ranges."""
+    if not isinstance(origin_data, dict):
+        return False
+    try:
+        lat = float(origin_data['lat'])
+        lon = float(origin_data['lon'])
+        alt = float(origin_data['alt'])
+    except (KeyError, TypeError, ValueError):
+        return False
+    if not all(math.isfinite(v) for v in (lat, lon, alt)):
+        return False
+    if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+        return False
+    return True
 
 
 def save_origin_to_cache(origin_data: Dict) -> bool:
@@ -64,6 +82,10 @@ def save_origin_to_cache(origin_data: Dict) -> bool:
         True
     """
     try:
+        if not _validate_origin_coords(origin_data):
+            logger.warning("Refusing to cache origin with invalid lat/lon/alt")
+            return False
+
         # Ensure cache directory exists
         CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -107,6 +129,10 @@ def load_origin_from_cache() -> Optional[Dict]:
         required_fields = ['lat', 'lon', 'alt']
         if not all(field in origin_data for field in required_fields):
             logger.warning("Cache file missing required fields, ignoring")
+            return None
+
+        if not _validate_origin_coords(origin_data):
+            logger.warning("Cache file has invalid lat/lon/alt, ignoring")
             return None
 
         logger.debug(f"Loaded origin from cache: lat={origin_data['lat']:.6f}, "

--- a/tests/test_origin_cache.py
+++ b/tests/test_origin_cache.py
@@ -1,0 +1,57 @@
+"""Unit tests for local origin cache validation."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def cache_paths(tmp_path, monkeypatch):
+    import src.origin_cache as oc
+
+    cache_dir = tmp_path / "cache"
+    cache_file = cache_dir / "origin_cache.json"
+    monkeypatch.setattr(oc, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(oc, "CACHE_FILE", cache_file)
+    return oc, cache_file
+
+
+def test_save_and_load_roundtrip(cache_paths):
+    oc, cache_file = cache_paths
+    payload = {"lat": 35.1, "lon": -120.5, "alt": 100.0, "source": "test"}
+    assert oc.save_origin_to_cache(payload) is True
+    assert cache_file.exists()
+    loaded = oc.load_origin_from_cache()
+    assert loaded is not None
+    assert loaded["lat"] == 35.1
+    assert loaded["lon"] == -120.5
+    assert loaded["alt"] == 100.0
+    assert "cached_at" in loaded
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"lat": 91.0, "lon": 0.0, "alt": 1.0},
+        {"lat": 0.0, "lon": 200.0, "alt": 1.0},
+        {"lat": "n/a", "lon": 0.0, "alt": 1.0},
+        {"lat": 0.0, "lon": 0.0, "alt": math.inf},
+        {"lat": math.nan, "lon": 0.0, "alt": 1.0},
+        {"lat": 0.0, "lon": 0.0},  # missing alt
+    ],
+)
+def test_save_rejects_invalid_origin(cache_paths, bad):
+    oc, cache_file = cache_paths
+    assert oc.save_origin_to_cache(dict(bad)) is False
+    assert not cache_file.exists()
+
+
+def test_load_rejects_invalid_cached_values(cache_paths):
+    oc, cache_file = cache_paths
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(json.dumps({"lat": 12.0, "lon": -999.0, "alt": 10.0}))
+    assert oc.load_origin_from_cache() is None


### PR DESCRIPTION
## Summary
- Validate lat/lon/alt as finite floats with WGS84 lat/lon ranges before origin cache save/load.
- Add `tests/test_origin_cache.py` with roundtrip + rejection cases (tmp cache path).

## Motivation
Cache previously required only key presence. Non-numeric, out-of-range, or non-finite values could be written or returned and break formatters / coordinate projection.

## Verification
- Offline unit checks for save/load validation paths (tmp_path-style CACHE_FILE override).

## Safety
- Fail-closed caching only; no geofence/arming changes.
