### PR TITLE
fix: reject non-finite values in network_status env float/int helpers

### DIFF
--- a/src/network_status.py
+++ b/src/network_status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import socket
 import subprocess
@@ -29,13 +30,22 @@ def _env_float(name: str, default: float, minimum: float | None = None) -> float
         value = float(os.getenv(name, str(default)))
     except (TypeError, ValueError):
         value = default
+    else:
+        # Non-finite env values must not poison socket/subprocess timeouts.
+        if not math.isfinite(value):
+            value = default
     return max(minimum, value) if minimum is not None else value
 
 
 def _env_int(name: str, default: int, minimum: int | None = None) -> int:
     try:
-        value = int(float(os.getenv(name, str(default))))
-    except (TypeError, ValueError):
+        # Guard non-finite floats before int() (OverflowError on ±inf in CPython).
+        parsed = float(os.getenv(name, str(default)))
+        if not math.isfinite(parsed):
+            value = default
+        else:
+            value = int(parsed)
+    except (TypeError, ValueError, OverflowError):
         value = default
     return max(minimum, value) if minimum is not None else value
 

--- a/tests/test_network_status.py
+++ b/tests/test_network_status.py
@@ -126,3 +126,30 @@ def test_build_network_info_handles_missing_nmcli(monkeypatch):
     assert payload["ethernet"] is None
     assert payload["primary_link"] is None
     assert payload["internet"]["reachable"] is False
+
+
+def test_env_float_rejects_non_finite(monkeypatch):
+    import math
+
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "nan")
+    assert network_status._env_float("MDS_TEST_ENV_FLOAT", 1.5) == 1.5
+
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "inf")
+    assert network_status._env_float("MDS_TEST_ENV_FLOAT", 2.0, minimum=0.2) == 2.0
+
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "-inf")
+    assert network_status._env_float("MDS_TEST_ENV_FLOAT", 3.0, minimum=1.0) == 3.0
+
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "0.05")
+    assert network_status._env_float("MDS_TEST_ENV_FLOAT", 1.0, minimum=0.2) == 0.2
+
+
+def test_env_int_rejects_non_finite_and_overflow(monkeypatch):
+    monkeypatch.setenv("MDS_TEST_ENV_INT", "nan")
+    assert network_status._env_int("MDS_TEST_ENV_INT", 7) == 7
+
+    monkeypatch.setenv("MDS_TEST_ENV_INT", "inf")
+    assert network_status._env_int("MDS_TEST_ENV_INT", 8, minimum=1) == 8
+
+    monkeypatch.setenv("MDS_TEST_ENV_INT", "4.2")
+    assert network_status._env_int("MDS_TEST_ENV_INT", 0, minimum=1) == 4


### PR DESCRIPTION
## Summary
- `_env_float` / `_env_int` in `src/network_status.py` now treat NaN/±inf (and overflow on int coercion) like parse failures and use the caller default before optional minimum clamps.
- Adds focused unit tests for non-finite env overrides.

## Motivation
Internet check timeout/interval and related env parsers could accept `inf`/`nan`, which can poison socket and subprocess timeout calculus. Align with the repo fail-closed numeric policy.

## Verification
- Manual helper asserts (host lacks pyproj for full pytest): non-finite float/int env → defaults; finite values still clamp to minimum.

## Spec
`specs/mavsdk-drone-show/2026-07-15-1.md` (Composer Standard scope; micro-diff on fork + Bartok review).