### PR TITLE
fix: reject non-finite ULog summary timeout env overrides

### DIFF
--- a/src/ulog_proxy_policy.py
+++ b/src/ulog_proxy_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 
 
@@ -27,4 +28,7 @@ def drone_ulog_summary_timeout_seconds() -> float:
         )
     except (TypeError, ValueError):
         return DEFAULT_DRONE_ULOG_SUMMARY_TIMEOUT_SECONDS
-    return value if value > 0 else DEFAULT_DRONE_ULOG_SUMMARY_TIMEOUT_SECONDS
+    # Non-finite or non-positive overrides must not yield unbounded client waits.
+    if not math.isfinite(value) or value <= 0:
+        return DEFAULT_DRONE_ULOG_SUMMARY_TIMEOUT_SECONDS
+    return value

--- a/tests/test_ulog_proxy_policy.py
+++ b/tests/test_ulog_proxy_policy.py
@@ -1,0 +1,28 @@
+"""Unit tests for shared ULog proxy timeout policy."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.ulog_proxy_policy import (
+    DEFAULT_DRONE_ULOG_SUMMARY_TIMEOUT_SECONDS,
+    drone_ulog_summary_timeout_seconds,
+)
+
+
+def test_summary_timeout_default_without_env(monkeypatch):
+    monkeypatch.delenv("MDS_ULOG_SUMMARY_TIMEOUT_SEC", raising=False)
+    assert drone_ulog_summary_timeout_seconds() == DEFAULT_DRONE_ULOG_SUMMARY_TIMEOUT_SECONDS
+
+
+def test_summary_timeout_accepts_positive_finite(monkeypatch):
+    monkeypatch.setenv("MDS_ULOG_SUMMARY_TIMEOUT_SEC", "12.5")
+    assert drone_ulog_summary_timeout_seconds() == pytest.approx(12.5)
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "nan", "inf", "-inf", "invalid"])
+def test_summary_timeout_rejects_bad_overrides(monkeypatch, raw):
+    monkeypatch.setenv("MDS_ULOG_SUMMARY_TIMEOUT_SEC", raw)
+    assert drone_ulog_summary_timeout_seconds() == DEFAULT_DRONE_ULOG_SUMMARY_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary
- `drone_ulog_summary_timeout_seconds` now requires a **finite**, strictly positive env override; NaN/±inf/≤0/invalid fall back to the default (90s).
- Adds `tests/test_ulog_proxy_policy.py`.

## Motivation
`value > 0` alone accepted `+inf`, which can produce non-credible HTTP client timeouts for staged ULog summary parsing.

## Verification
- Manual asserts for default, 12.5, and bad overrides (nan/inf/0/-1/invalid).

## Spec
`specs/mavsdk-drone-show/2026-07-15-2.md`.