### PR TITLE
fix: reject non-finite values in Params._safe_float env helper

### DIFF
--- a/src/params.py
+++ b/src/params.py
@@ -18,6 +18,7 @@ from src.drone_api_routes import (
     DRONE_STATE_ROUTE,
 )
 from src.gcs_api_routes import GCS_FLEET_HEARTBEATS_ROUTE
+import math
 
 logger = get_logger("params")
 
@@ -48,7 +49,13 @@ def _safe_int(value: str, default: int) -> int:
 def _safe_float(value: str, default: float) -> float:
     """Safely convert string to float with fallback to default."""
     try:
-        return float(value)
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            logger.warning(
+                f"Non-finite float value {value!r}, using default {default}"
+            )
+            return default
+        return parsed
     except (ValueError, TypeError):
         logger.warning(f"Invalid float value '{value}', using default {default}")
         return default

--- a/tests/test_params_safe_float.py
+++ b/tests/test_params_safe_float.py
@@ -1,0 +1,25 @@
+"""Unit tests for Params._safe_float non-finite rejection."""
+
+import math
+
+import src.params as params_mod
+
+
+def test_safe_float_finite():
+    assert params_mod._safe_float("1.5", 0.0) == 1.5
+    assert params_mod._safe_float("2", 0.0) == 2.0
+
+
+def test_safe_float_invalid_uses_default():
+    assert params_mod._safe_float("not-a-number", 3.25) == 3.25
+    assert params_mod._safe_float(None, 9.0) == 9.0  # type: ignore[arg-type]
+
+
+def test_safe_float_non_finite_uses_default():
+    assert params_mod._safe_float("inf", 4.0) == 4.0
+    assert params_mod._safe_float("-inf", 5.0) == 5.0
+    assert params_mod._safe_float("nan", 6.0) == 6.0
+    assert params_mod._safe_float("NaN", 7.0) == 7.0
+    # numeric non-finite inputs if callers pass them
+    assert params_mod._safe_float(math.inf, 8.0) == 8.0  # type: ignore[arg-type]
+    assert params_mod._safe_float(math.nan, 1.25) == 1.25  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Teach `src/params.py` `_safe_float` to reject IEEE NaN/±inf after parse and fall back to the provided default (same as invalid strings).
- Add focused unit coverage in `tests/test_params_safe_float.py`.

## Motivation
Env overrides such as `MDS_PRESENCE_STALE_SEC=inf` or garbage non-finite float strings previously became real class attributes. Presence TTL and PX4 parameter-metadata timeout paths then inherit poison values. Matches fail-closed numeric policy already used in `telemetry_display._finite_float` and related hardening PRs.

## Verification
```
python3 -m pytest tests/test_params_safe_float.py -q -o addopts= --noconftest
# 3 passed
```

## Notes
AI-assisted design; human-reviewed micro-diff. Docs/safety-only numeric guard — no geofence/arm changes.