### PR TITLE
fix: fail closed on non-finite live armability timeout components

### DIFF
--- a/src/live_armability_utils.py
+++ b/src/live_armability_utils.py
@@ -2,6 +2,20 @@
 
 from __future__ import annotations
 
+import math
+from typing import Any
+
+
+def _finite_component(value: Any, default: float) -> float:
+    """Coerce to float; non-finite or invalid values use default."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(parsed):
+        return default
+    return parsed
+
 
 def calculate_live_armability_request_timeout(*, params) -> float:
     """
@@ -13,14 +27,23 @@ def calculate_live_armability_request_timeout(*, params) -> float:
     """
     connect_timeout = max(
         0.1,
-        float(getattr(params, "LIVE_ARMABILITY_PROBE_CONNECT_TIMEOUT_SEC", 5.0)),
+        _finite_component(
+            getattr(params, "LIVE_ARMABILITY_PROBE_CONNECT_TIMEOUT_SEC", 5.0),
+            5.0,
+        ),
     )
     probe_timeout = max(
         0.1,
-        float(getattr(params, "LIVE_ARMABILITY_PROBE_TIMEOUT_SEC", 6.0)),
+        _finite_component(
+            getattr(params, "LIVE_ARMABILITY_PROBE_TIMEOUT_SEC", 6.0),
+            6.0,
+        ),
     )
     http_buffer_sec = max(
         0.5,
-        float(getattr(params, "LIVE_ARMABILITY_PROBE_HTTP_BUFFER_SEC", 2.0)),
+        _finite_component(
+            getattr(params, "LIVE_ARMABILITY_PROBE_HTTP_BUFFER_SEC", 2.0),
+            2.0,
+        ),
     )
     return connect_timeout + probe_timeout + http_buffer_sec

--- a/tests/test_live_armability_utils.py
+++ b/tests/test_live_armability_utils.py
@@ -1,0 +1,42 @@
+"""Tests for live armability timeout helper."""
+
+import math
+from types import SimpleNamespace
+
+from src.live_armability_utils import calculate_live_armability_request_timeout
+
+
+def test_happy_path_sums_components():
+    params = SimpleNamespace(
+        LIVE_ARMABILITY_PROBE_CONNECT_TIMEOUT_SEC=5.0,
+        LIVE_ARMABILITY_PROBE_TIMEOUT_SEC=6.0,
+        LIVE_ARMABILITY_PROBE_HTTP_BUFFER_SEC=2.0,
+    )
+    assert calculate_live_armability_request_timeout(params=params) == 13.0
+
+
+def test_applies_minimum_floors():
+    params = SimpleNamespace(
+        LIVE_ARMABILITY_PROBE_CONNECT_TIMEOUT_SEC=0.01,
+        LIVE_ARMABILITY_PROBE_TIMEOUT_SEC=0.01,
+        LIVE_ARMABILITY_PROBE_HTTP_BUFFER_SEC=0.01,
+    )
+    assert calculate_live_armability_request_timeout(params=params) == 0.1 + 0.1 + 0.5
+
+
+def test_non_finite_falls_back_to_defaults():
+    params = SimpleNamespace(
+        LIVE_ARMABILITY_PROBE_CONNECT_TIMEOUT_SEC=math.inf,
+        LIVE_ARMABILITY_PROBE_TIMEOUT_SEC=math.nan,
+        LIVE_ARMABILITY_PROBE_HTTP_BUFFER_SEC=float("-inf"),
+    )
+    assert calculate_live_armability_request_timeout(params=params) == 5.0 + 6.0 + 2.0
+
+
+def test_invalid_type_falls_back():
+    params = SimpleNamespace(
+        LIVE_ARMABILITY_PROBE_CONNECT_TIMEOUT_SEC="bad",
+        LIVE_ARMABILITY_PROBE_TIMEOUT_SEC=None,
+        LIVE_ARMABILITY_PROBE_HTTP_BUFFER_SEC=object(),
+    )
+    assert calculate_live_armability_request_timeout(params=params) == 13.0


### PR DESCRIPTION
## Summary
- Coerce live armability timeout components through a finite-or-default helper before applying minimum floors.
- Cover happy path, floors, non-finite fallback, and invalid types in `tests/test_live_armability_utils.py`.

## Motivation
`calculate_live_armability_request_timeout` previously `float()`-cast Params attrs and could surface non-finite HTTP budgets if config/env poisoned those attrs. Fail closed to documented defaults instead.

## Verification
```
python3 -m pytest tests/test_live_armability_utils.py -q -o addopts= --noconftest
# 4 passed
```

## Notes
AI-assisted design; human-reviewed. Scope limited to timeout **budget math** only — no arm/disarm authority changes.