### PR TITLE
fix: reject non-finite fleet presence threshold decimals

### DIFF
--- a/gcs-server/presence.py
+++ b/gcs-server/presence.py
@@ -7,6 +7,7 @@ preflight, and command routing do not drift into different definitions of
 
 from __future__ import annotations
 
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -26,7 +27,9 @@ def _safe_float(value: Any, default: float) -> float:
         parsed = float(value)
     except (TypeError, ValueError):
         return default
-    return parsed if parsed >= 0 else default
+    if not math.isfinite(parsed) or parsed < 0:
+        return default
+    return parsed
 
 
 def resolve_presence_thresholds(params: Any | None = None) -> PresenceThresholds:

--- a/tests/test_presence_safe_float.py
+++ b/tests/test_presence_safe_float.py
@@ -1,0 +1,37 @@
+"""Unit tests for gcs-server presence threshold float sanitization."""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gcs-server"))
+
+from presence import _safe_float, resolve_presence_thresholds
+
+
+def test_safe_float_rejects_non_finite_and_negative():
+    assert _safe_float("inf", 7.0) == 7.0
+    assert _safe_float("-inf", 7.0) == 7.0
+    assert _safe_float("nan", 7.0) == 7.0
+    assert _safe_float(-1, 7.0) == 7.0
+    assert _safe_float("nope", 7.0) == 7.0
+    assert _safe_float("12.5", 7.0) == 12.5
+    assert _safe_float(0, 7.0) == 0.0
+
+
+def test_resolve_presence_thresholds_env_inf_falls_back(monkeypatch):
+    params = SimpleNamespace(
+        TELEMETRY_POLLING_TIMEOUT=5.0,
+        heartbeat_interval=5.0,
+        PRESENCE_RECENT_LOSS_SEC=30.0,
+        PRESENCE_STALE_SEC=60.0,
+        PRESENCE_LONG_OFFLINE_SEC=300.0,
+    )
+    monkeypatch.setenv("MDS_PRESENCE_STALE_SEC", "inf")
+    monkeypatch.delenv("MDS_PRESENCE_RECENT_LOSS_SEC", raising=False)
+    monkeypatch.delenv("MDS_PRESENCE_LONG_OFFLINE_SEC", raising=False)
+    thresholds = resolve_presence_thresholds(params)
+    assert thresholds.stale_sec == 60.0
+    assert thresholds.live_sec == 10.0  # max(5, 5*2)


### PR DESCRIPTION
## Summary
- Harden `gcs-server/presence.py` `_safe_float` so parsed values must be finite **and** non-negative before use.
- Prevents `MDS_PRESENCE_*` / Params `inf`/`nan` from yielding unbounded live/stale/offline windows.
- Adds focused unit coverage under `tests/test_presence_safe_float.py`.

## Motivation
`float("inf") >= 0` is true, so the previous `parsed >= 0` guard treated infinite env overrides as valid thresholds. Fleet presence classifications then drift into unusable states for operators and preflight routing.

## Verification
- Manual/unit-style run of `_safe_float` + `resolve_presence_thresholds` with `MDS_PRESENCE_STALE_SEC=inf` → falls back to Params default (60s).
- Full pytest suite needs project venv (`pyproj`); change is isolated to presence sanitization.

AI-assisted; human-reviewed.