### PR TITLE
fix: fail closed on non-finite precision-move/swarm timeout floats

### DIFF
--- a/gcs-server/command_timeout_policy.py
+++ b/gcs-server/command_timeout_policy.py
@@ -5,6 +5,7 @@ Mission-aware tracker timeout policy for command lifecycle monitoring.
 from __future__ import annotations
 
 import csv
+import math
 import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
@@ -43,6 +44,17 @@ def _safe_int(value: Any, default: int) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _safe_finite_float(value: Any, default: float) -> float:
+    """Parse a float that must be finite; otherwise return default."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(parsed):
+        return default
+    return parsed
 
 
 def _target_drone_file_names(target_drone_ids: Optional[Iterable[Any]]) -> set[str] | None:
@@ -213,16 +225,20 @@ def estimate_command_tracking_timeout_ms(
 
     if mission_enum == Mission.PRECISION_MOVE:
         precision_move = (command_data or {}).get("precision_move") or {}
-        try:
-            requested_timeout_sec = float(precision_move.get("timeout_sec"))
-        except (TypeError, ValueError):
-            requested_timeout_sec = float(
-                getattr(
-                    params,
-                    "COMMAND_TRACKING_PRECISION_MOVE_TIMEOUT_SEC",
-                    getattr(params, "PRECISION_MOVE_DEFAULT_TIMEOUT_SEC", 30.0),
-                )
-            )
+        fallback_timeout_sec = _safe_finite_float(
+            getattr(
+                params,
+                "COMMAND_TRACKING_PRECISION_MOVE_TIMEOUT_SEC",
+                getattr(params, "PRECISION_MOVE_DEFAULT_TIMEOUT_SEC", 30.0),
+            ),
+            30.0,
+        )
+        requested_timeout_sec = _safe_finite_float(
+            precision_move.get("timeout_sec"),
+            fallback_timeout_sec,
+        )
+        if requested_timeout_sec <= 0:
+            requested_timeout_sec = fallback_timeout_sec if fallback_timeout_sec > 0 else 30.0
         return max(default_ms, trigger_delay_ms + int((requested_timeout_sec + action_buffer_sec) * 1000))
 
     if mission_enum == Mission.SMART_SWARM:
@@ -253,7 +269,7 @@ def estimate_command_tracking_timeout_ms(
             else None
         )
         if processed_duration_s is not None:
-            multiplier = max(1.0, float(getattr(params, "SWARM_TRAJECTORY_TIMEOUT_MULTIPLIER", 1.2)))
+            multiplier = max(1.0, _safe_finite_float(getattr(params, "SWARM_TRAJECTORY_TIMEOUT_MULTIPLIER", 1.2), 1.2))
             total_duration_s = (processed_duration_s * multiplier) + mission_buffer_sec
             end_behavior = str(
                 (command_data or {}).get("return_behavior")

--- a/tests/test_command_timeout_policy.py
+++ b/tests/test_command_timeout_policy.py
@@ -170,3 +170,30 @@ def test_estimate_command_tracking_timeout_for_custom_show_uses_active_csv_durat
     )
 
     assert timeout_ms == 32_500 + (120 * 1000)
+
+def test_estimate_command_tracking_timeout_for_precision_move_rejects_non_finite_request():
+    timeout_ms = estimate_command_tracking_timeout_ms(
+        Mission.PRECISION_MOVE,
+        command_data={"precision_move": {"timeout_sec": "inf"}},
+        params=_MockParams,
+    )
+    # Falls back to COMMAND_TRACKING_PRECISION_MOVE_TIMEOUT_SEC=45 + buffer 30
+    assert timeout_ms == (45 + 30) * 1000
+
+
+def test_estimate_command_tracking_timeout_for_precision_move_rejects_non_positive_request():
+    timeout_ms = estimate_command_tracking_timeout_ms(
+        Mission.PRECISION_MOVE,
+        command_data={"precision_move": {"timeout_sec": -5}},
+        params=_MockParams,
+    )
+    assert timeout_ms == (45 + 30) * 1000
+
+def test_safe_finite_float_and_swarm_multiplier_guard():
+    from command_timeout_policy import _safe_finite_float
+
+    assert _safe_finite_float("inf", 1.2) == 1.2
+    assert _safe_finite_float("nan", 1.2) == 1.2
+    assert _safe_finite_float("1.5", 1.2) == 1.5
+    # Mirrors SWARM_TRAJECTORY branch: max(1.0, safe(...))
+    assert max(1.0, _safe_finite_float(float("inf"), 1.2)) == 1.2


### PR DESCRIPTION
## Summary
- Add `_safe_finite_float` next to `_safe_int` in `gcs-server/command_timeout_policy.py`.
- PRECISION_MOVE tracker budgets reject non-finite / non-positive `timeout_sec` and fall back to Params defaults.
- SWARM_TRAJECTORY duration multiplier uses the same finite guard so `inf` cannot explode tracking windows.

## Motivation
Operator or agent payloads can put `"timeout_sec": "inf"` (or Params can be overridden to nan/inf). Bare `float()` then feeds `int((…)*1000)` and produces unbounded/invalid command tracker and mission UI hang risk without changing arm or geofence rules.

## Verification
- Smoke assertions: PRECISION_MOVE with `timeout_sec` `inf`/`-5` → (45+30)s budget from mock Params.
- `_safe_finite_float("inf", 1.2) == 1.2`.
- Project-wide pytest needs full venv; focused logic verified offline.

AI-assisted; human-reviewed.