### PR TITLE
fix: ignore non-finite heartbeat first_seen when normalizing ms

### DIFF
--- a/gcs-server/telemetry.py
+++ b/gcs-server/telemetry.py
@@ -13,6 +13,7 @@ import requests
 import threading
 import time
 import logging
+import math
 from typing import Any, Dict
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
@@ -82,7 +83,7 @@ def _normalize_heartbeat_first_seen(value):
     except (TypeError, ValueError):
         return None
 
-    if numeric_value <= 0:
+    if not math.isfinite(numeric_value) or numeric_value <= 0:
         return None
 
     if numeric_value < 1_000_000_000_000:

--- a/tests/test_heartbeat_first_seen_finite.py
+++ b/tests/test_heartbeat_first_seen_finite.py
@@ -1,0 +1,28 @@
+"""Unit tests for non-finite heartbeat first_seen normalization."""
+
+from __future__ import annotations
+
+import math
+
+import telemetry as tel
+
+
+def test_normalize_heartbeat_first_seen_rejects_non_finite() -> None:
+    assert tel._normalize_heartbeat_first_seen(float("inf")) is None
+    assert tel._normalize_heartbeat_first_seen(float("nan")) is None
+    assert tel._normalize_heartbeat_first_seen("inf") is None
+    assert tel._normalize_heartbeat_first_seen("nan") is None
+
+
+def test_normalize_heartbeat_first_seen_rejects_non_positive_and_garbage() -> None:
+    assert tel._normalize_heartbeat_first_seen(-1) is None
+    assert tel._normalize_heartbeat_first_seen(0) is None
+    assert tel._normalize_heartbeat_first_seen("") is None
+    assert tel._normalize_heartbeat_first_seen(None) is None
+    assert tel._normalize_heartbeat_first_seen("nope") is None
+
+
+def test_normalize_heartbeat_first_seen_seconds_to_ms() -> None:
+    assert tel._normalize_heartbeat_first_seen(1699999999.0) == 1699999999000
+    assert tel._normalize_heartbeat_first_seen(1699999999000) == 1699999999000
+    assert math.isfinite(float(tel._normalize_heartbeat_first_seen(1700000000.0)))


### PR DESCRIPTION
## Summary
`_normalize_heartbeat_first_seen` now requires `math.isfinite` and `> 0` before the second→millisecond heuristic and `int()` cast. Non-finite values return `None` like other bad inputs.

## Why
`float("inf")` is not `<= 0`, so it previously reached `int(inf)` (OverflowError) or nonsensical epoch ms and could break degraded telemetry / API fields that embed `heartbeat_first_seen`.

## Tests
```bash
PYTHONPATH=gcs-server:.:src python3 -m pytest tests/test_heartbeat_first_seen_finite.py -q -o addopts= --noconftest
# 3 passed
```

Human-reviewed; AI-assisted drafting.