### PR TITLE
fix: reject non-finite first waypoint coords in trajectory lookup

### DIFF
--- a/src/coordinate_utils.py
+++ b/src/coordinate_utils.py
@@ -10,6 +10,7 @@ that were previously scattered across multiple files.
 
 import csv
 import logging
+import math
 import os
 from pathlib import Path
 from typing import Optional, Tuple
@@ -153,6 +154,14 @@ def get_expected_position_from_trajectory(
             # These represent the canonical expected position for this pos_id
             expected_north = float(first_waypoint.get('px', 0))
             expected_east = float(first_waypoint.get('py', 0))
+
+            if not (math.isfinite(expected_north) and math.isfinite(expected_east)):
+                logger.error(
+                    f"Non-finite first waypoint coordinates for pos_id={pos_id}: "
+                    f"North={expected_north!r}, East={expected_east!r} "
+                    f"(from {trajectory_file})"
+                )
+                return None, None
 
             logger.debug(
                 f"Expected position for pos_id={pos_id}: "

--- a/tests/test_coordinate_utils.py
+++ b/tests/test_coordinate_utils.py
@@ -183,6 +183,30 @@ class TestGetExpectedPositionFromTrajectory:
         assert north == 12.0
         assert east == -3.5
 
+    def test_nonfinite_px_returns_none(self, tmp_path):
+        """Non-finite px must not become an expected position."""
+        from src.coordinate_utils import get_expected_position_from_trajectory
+
+        trajectory_dir = tmp_path / "shapes" / "swarm" / "processed"
+        trajectory_dir.mkdir(parents=True)
+        (trajectory_dir / "Drone 1.csv").write_text(
+            "t,px,py,pz,vx,vy,vz\n0.0,inf,1.0,0,0,0,0\n"
+        )
+        north, east = get_expected_position_from_trajectory(1, sim_mode=False, base_dir=str(tmp_path))
+        assert north is None and east is None
+
+    def test_nonfinite_py_nan_returns_none(self, tmp_path):
+        """NaN py must not become an expected position."""
+        from src.coordinate_utils import get_expected_position_from_trajectory
+
+        trajectory_dir = tmp_path / "shapes" / "swarm" / "processed"
+        trajectory_dir.mkdir(parents=True)
+        (trajectory_dir / "Drone 1.csv").write_text(
+            "t,px,py,pz,vx,vy,vz\n0.0,1.5,nan,0,0,0,0\n"
+        )
+        north, east = get_expected_position_from_trajectory(1, sim_mode=False, base_dir=str(tmp_path))
+        assert north is None and east is None
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
`get_expected_position_from_trajectory` rejects inf/nan first-row px/py and returns (None, None).

## Verification
pytest tests/test_coordinate_utils.py - 13 passed

Fail-closed only; no arm/geofence. AI-assisted; human-reviewed.
