### PR TITLE
fix: reject non-finite synchronized start time and late tolerance

### DIFF
--- a/src/synchronized_start.py
+++ b/src/synchronized_start.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import math
 import time
 from typing import Optional
 
@@ -40,6 +41,13 @@ def resolve_requested_start_time(
             )
         return None
 
+    if not math.isfinite(normalized):
+        if logger is not None:
+            logger.warning(
+                "Non-finite synchronized start time provided. Immediate launch will anchor at the local startup gate."
+            )
+        return None
+
     if normalized <= 0:
         if logger is not None:
             logger.info(
@@ -63,8 +71,20 @@ def evaluate_synchronized_start(
     `synchronized_start_time` is expected to be an epoch-second timestamp.
     A value of `None`, `0`, or a negative number means "start immediately".
     """
-    resolved_now = float(time.time() if now is None else now)
-    tolerance = max(0.0, float(late_tolerance_sec))
+    try:
+        resolved_now = float(time.time() if now is None else now)
+    except (TypeError, ValueError):
+        resolved_now = float(time.time())
+    if not math.isfinite(resolved_now):
+        resolved_now = float(time.time())
+
+    try:
+        tolerance = float(late_tolerance_sec)
+    except (TypeError, ValueError):
+        tolerance = 0.0
+    if not math.isfinite(tolerance):
+        tolerance = 0.0
+    tolerance = max(0.0, tolerance)
 
     if synchronized_start_time is None:
         return SynchronizedStartDecision(
@@ -86,6 +106,16 @@ def evaluate_synchronized_start(
             should_wait=False,
             should_abort=False,
             reason="Invalid start_time provided; using now.",
+        )
+
+    if not math.isfinite(requested_start_time):
+        return SynchronizedStartDecision(
+            effective_start_time=resolved_now,
+            wait_seconds=0.0,
+            late_by_seconds=0.0,
+            should_wait=False,
+            should_abort=False,
+            reason="Non-finite start_time provided; using now.",
         )
 
     if requested_start_time <= 0:

--- a/tests/test_synchronized_start.py
+++ b/tests/test_synchronized_start.py
@@ -46,3 +46,41 @@ def test_resolve_requested_start_time_defers_immediate_launch_until_start_gate()
 
 def test_resolve_requested_start_time_preserves_future_timestamp():
     assert resolve_requested_start_time(110.0) == pytest.approx(110.0)
+
+def test_resolve_requested_start_time_rejects_nonfinite():
+    import math
+    from src.synchronized_start import resolve_requested_start_time
+
+    assert resolve_requested_start_time(float("nan")) is None
+    assert resolve_requested_start_time(float("inf")) is None
+    assert resolve_requested_start_time(float("-inf")) is None
+
+
+def test_evaluate_synchronized_start_rejects_nonfinite_start():
+    import math
+    from src.synchronized_start import evaluate_synchronized_start
+
+    decision = evaluate_synchronized_start(float("nan"), now=1_700_000_000.0)
+    assert decision.should_wait is False
+    assert decision.should_abort is False
+    assert decision.effective_start_time == 1_700_000_000.0
+    assert "Non-finite" in decision.reason or "Invalid" in decision.reason or "now" in decision.reason.lower()
+
+    decision_inf = evaluate_synchronized_start(float("inf"), now=1_700_000_000.0, late_tolerance_sec=5.0)
+    assert decision_inf.should_wait is False
+    assert decision_inf.effective_start_time == 1_700_000_000.0
+
+
+def test_evaluate_synchronized_start_nonfinite_tolerance_is_zero():
+    from src.synchronized_start import evaluate_synchronized_start
+
+    # start slightly in the past; non-finite tolerance must not inflate wait/late windows
+    decision = evaluate_synchronized_start(
+        1_700_000_000.0 - 0.1,
+        late_tolerance_sec=float("nan"),
+        now=1_700_000_000.0,
+    )
+    assert decision.should_abort is True or decision.late_by_seconds >= 0.0
+    # tolerance treated as 0 → past start without allowance
+    assert decision.should_wait is False
+


### PR DESCRIPTION
## What
Reject non-finite synchronized start time and late_tolerance_sec (nan/inf → invalid/0).

## Verification
pytest tests/test_synchronized_start.py - 9 passed

Timing helper only; no arm/takeoff path edits.
