### PR TITLE
fix: reject non-finite Smart Swarm offsets in runtime assignment

### DIFF
--- a/src/swarm_runtime_state.py
+++ b/src/swarm_runtime_state.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -33,12 +34,24 @@ def build_runtime_swarm_assignment(
     source = assignment or {}
     follow_value = force_follow if force_follow is not None else source.get("follow", 0)
 
+    def _finite_offset(key: str) -> float:
+        raw = source.get(key, 0.0)
+        try:
+            value = float(raw or 0.0)
+        except (TypeError, ValueError):
+            logger.debug("Non-numeric swarm offset %s=%r; using 0.0", key, raw)
+            return 0.0
+        if not math.isfinite(value):
+            logger.debug("Non-finite swarm offset %s=%r; using 0.0", key, raw)
+            return 0.0
+        return value
+
     return {
         "hw_id": int(hw_id),
         "follow": int(follow_value or 0),
-        "offset_x": float(source.get("offset_x", 0.0) or 0.0),
-        "offset_y": float(source.get("offset_y", 0.0) or 0.0),
-        "offset_z": float(source.get("offset_z", 0.0) or 0.0),
+        "offset_x": _finite_offset("offset_x"),
+        "offset_y": _finite_offset("offset_y"),
+        "offset_z": _finite_offset("offset_z"),
         "frame": str(source.get("frame", "body") or "body").lower(),
     }
 

--- a/tests/test_swarm_runtime_state.py
+++ b/tests/test_swarm_runtime_state.py
@@ -69,3 +69,32 @@ def test_build_runtime_swarm_assignment_force_follow_overrides_source():
 
     assert assignment["follow"] == 0
     assert assignment["offset_x"] == 25.0
+
+
+def test_build_runtime_swarm_assignment_rejects_nonfinite_offsets():
+    assignment = build_runtime_swarm_assignment(
+        9,
+        {
+            "follow": 1,
+            "offset_x": float("inf"),
+            "offset_y": "nan",
+            "offset_z": "-inf",
+            "frame": "ned",
+        },
+    )
+
+    assert assignment["offset_x"] == 0.0
+    assert assignment["offset_y"] == 0.0
+    assert assignment["offset_z"] == 0.0
+    assert assignment["frame"] == "ned"
+    assert assignment["hw_id"] == 9
+
+
+def test_build_runtime_swarm_assignment_keeps_finite_mixed_offsets():
+    assignment = build_runtime_swarm_assignment(
+        1,
+        {"offset_x": 1.25, "offset_y": "0", "offset_z": -3.5, "frame": "body"},
+    )
+    assert assignment["offset_x"] == 1.25
+    assert assignment["offset_y"] == 0.0
+    assert assignment["offset_z"] == -3.5


### PR DESCRIPTION
## Summary
`build_runtime_swarm_assignment` now coerces non-finite `offset_x`/`offset_y`/`offset_z` to `0.0` when building the canonical cross-process Smart Swarm assignment.

## Why
Non-finite offsets parse via bare `float` and can poison follower geometry for the duration of the runtime assignment.

## Test plan
- Extended `tests/test_swarm_runtime_state.py` with inf/nan and finite cases
- Isolated smoke import of the module

AI-assisted; human-reviewed. No arm/geofence changes.