### PR TITLE
fix: reject non-finite first waypoint NE in trajectory lookup

### DIFF
--- a/src/coordinate_utils.py
+++ b/src/coordinate_utils.py
@@ -9,6 +9,7 @@ that were previously scattered across multiple files.
 """
 
 import csv
+import math
 import logging
 import os
 from pathlib import Path
@@ -153,6 +154,17 @@ def get_expected_position_from_trajectory(
             # These represent the canonical expected position for this pos_id
             expected_north = float(first_waypoint.get('px', 0))
             expected_east = float(first_waypoint.get('py', 0))
+
+            if not (math.isfinite(expected_north) and math.isfinite(expected_east)):
+                logger.error(
+                    "Non-finite first waypoint NE for pos_id=%s in %s "
+                    "(north=%r east=%r); refusing expected position",
+                    pos_id,
+                    trajectory_file,
+                    expected_north,
+                    expected_east,
+                )
+                return None, None
 
             logger.debug(
                 f"Expected position for pos_id={pos_id}: "

--- a/tests/test_coordinate_utils.py
+++ b/tests/test_coordinate_utils.py
@@ -186,3 +186,25 @@ class TestGetExpectedPositionFromTrajectory:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+def test_get_expected_position_rejects_nonfinite_first_waypoint(tmp_path):
+    """Fail closed when trajectory first px/py is nan/inf."""
+    import math
+    from src.coordinate_utils import get_expected_position_from_trajectory
+
+    traj_dir = tmp_path / "shapes" / "swarm" / "processed"
+    traj_dir.mkdir(parents=True)
+    csv_path = traj_dir / "Drone 1.csv"
+    csv_path.write_text("t,px,py,pz\n0,nan,1.0,0\n", encoding="utf-8")
+    north, east = get_expected_position_from_trajectory(1, base_dir=str(tmp_path))
+    assert north is None and east is None
+
+    csv_path.write_text("t,px,py,pz\n0,inf,2.0,0\n", encoding="utf-8")
+    north, east = get_expected_position_from_trajectory(1, base_dir=str(tmp_path))
+    assert north is None and east is None
+
+    csv_path.write_text("t,px,py,pz\n0,1.5,2.5,0\n", encoding="utf-8")
+    north, east = get_expected_position_from_trajectory(1, base_dir=str(tmp_path))
+    assert north == 1.5 and east == 2.5
+    assert math.isfinite(north) and math.isfinite(east)
+


### PR DESCRIPTION
## Summary
`get_expected_position_from_trajectory` parses the first CSV px/py with bare float(). Values like nan/inf still parse successfully and were returned as the canonical expected NED for a pos_id, which can poison auto position matching.

This change fail-closes: if either coordinate is non-finite, log and return (None, None) (same posture as missing/empty trajectory files). Adds a focused unit test covering nan, inf, and a finite happy path.

## Test plan
- [x] Local smoke: finite/non-finite CSV paths
- [ ] CI when environment has full deps

AI-assisted; human-reviewed. No geofence/arm changes.
