### PR TITLE
fix: reject non-finite SITL operation monitor timeout env

### DIFF
--- a/src/sitl_control_service.py
+++ b/src/sitl_control_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import platform
 import re
@@ -65,7 +66,9 @@ def _operation_monitor_timeout_seconds() -> float:
         value = float(os.getenv("MDS_SITL_OPERATION_MONITOR_TIMEOUT_SEC", "900"))
     except (TypeError, ValueError):
         return 900.0
-    return value if value > 0 else 900.0
+    if not math.isfinite(value) or value <= 0:
+        return 900.0
+    return value
 
 
 def _default_sitl_image() -> str:

--- a/tests/test_sitl_control_service.py
+++ b/tests/test_sitl_control_service.py
@@ -543,3 +543,17 @@ def test_build_image_release_command_includes_selected_flags(tmp_path):
     assert "--output-dir" in command
     assert "--archive-basename" in command
     assert "--no-compress" in command
+
+
+def test_operation_monitor_timeout_rejects_nonfinite(monkeypatch):
+    """Non-finite or non-positive env values fall back to 900s."""
+    from src import sitl_control_service as scs
+
+    monkeypatch.setenv("MDS_SITL_OPERATION_MONITOR_TIMEOUT_SEC", "nan")
+    assert scs._operation_monitor_timeout_seconds() == 900.0
+    monkeypatch.setenv("MDS_SITL_OPERATION_MONITOR_TIMEOUT_SEC", "inf")
+    assert scs._operation_monitor_timeout_seconds() == 900.0
+    monkeypatch.setenv("MDS_SITL_OPERATION_MONITOR_TIMEOUT_SEC", "-1")
+    assert scs._operation_monitor_timeout_seconds() == 900.0
+    monkeypatch.setenv("MDS_SITL_OPERATION_MONITOR_TIMEOUT_SEC", "120.5")
+    assert scs._operation_monitor_timeout_seconds() == 120.5


### PR DESCRIPTION
## Summary
`_operation_monitor_timeout_seconds` converted MDS_SITL_OPERATION_MONITOR_TIMEOUT_SEC with bare float() and only checked value > 0. Non-finite overrides (nan/inf) can poison operation monitor timers.

Require math.isfinite(value) and value > 0; otherwise keep the 900s default. Unit coverage for nan, inf, negative, and valid finite.

## Test plan
- [x] Local smoke of env edges
- [ ] CI full suite when available

Human-reviewed micro-fix. SITL timeout path only — no vehicle arm/geofence logic.
