### PR TITLE
fix: reject non-finite precision-move translation and timing fields

### DIFF
--- a/src/command_contract.py
+++ b/src/command_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -51,6 +52,7 @@ class PrecisionMoveYaw(BaseModel):
     )
     degrees: Optional[float] = Field(
         None,
+        allow_inf_nan=False,
         description="Yaw target in degrees. Meaning depends on mode.",
     )
 
@@ -64,6 +66,8 @@ class PrecisionMoveYaw(BaseModel):
 
         if self.degrees is None:
             raise ValueError("yaw.degrees is required unless yaw.mode is hold_current")
+        if not math.isfinite(float(self.degrees)):
+            raise ValueError("yaw.degrees must be a finite number")
 
         return self
 
@@ -86,26 +90,31 @@ class PrecisionMoveRequest(BaseModel):
     speed_m_s: Optional[float] = Field(
         None,
         gt=0,
+        allow_inf_nan=False,
         description="Requested approach speed in metres per second",
     )
     position_tolerance_m: Optional[float] = Field(
         None,
         gt=0,
+        allow_inf_nan=False,
         description="Position tolerance for convergence",
     )
     yaw_tolerance_deg: Optional[float] = Field(
         None,
         gt=0,
+        allow_inf_nan=False,
         description="Yaw tolerance for convergence",
     )
     settle_time_sec: Optional[float] = Field(
         None,
         gt=0,
+        allow_inf_nan=False,
         description="Time the drone must remain within tolerance before success",
     )
     timeout_sec: Optional[float] = Field(
         None,
         gt=0,
+        allow_inf_nan=False,
         description="Execution timeout budget",
     )
     hold_mode: PrecisionMoveHoldMode = Field(
@@ -132,9 +141,12 @@ class PrecisionMoveRequest(BaseModel):
             if not normalized_key:
                 raise ValueError("translation_m contains a blank key")
             try:
-                normalized[normalized_key] = float(raw_value)
+                parsed = float(raw_value)
             except (TypeError, ValueError) as exc:
                 raise ValueError(f"translation_m.{normalized_key} must be numeric") from exc
+            if not math.isfinite(parsed):
+                raise ValueError(f"translation_m.{normalized_key} must be a finite number")
+            normalized[normalized_key] = parsed
 
         return normalized
 

--- a/tests/test_command_contract_precision_move_finite.py
+++ b/tests/test_command_contract_precision_move_finite.py
@@ -1,0 +1,58 @@
+"""Fail-closed finite checks for precision-move command contract."""
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from src.command_contract import PrecisionMoveRequest
+
+
+def _base_body(**overrides):
+    payload = {
+        "frame": "body",
+        "translation_m": {"forward": 1.0, "right": 0.0, "up": 0.0},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_precision_move_accepts_finite_translation():
+    req = PrecisionMoveRequest.model_validate(_base_body())
+    assert req.translation_m["forward"] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf"), "nan", "inf"])
+def test_precision_move_rejects_nonfinite_translation(bad):
+    with pytest.raises((ValidationError, ValueError), match="finite"):
+        PrecisionMoveRequest.model_validate(
+            _base_body(translation_m={"forward": bad, "right": 0.0, "up": 0.0})
+        )
+
+
+@pytest.mark.parametrize("bad", [float("inf"), float("nan"), "inf"])
+def test_precision_move_rejects_nonfinite_speed(bad):
+    with pytest.raises(ValidationError):
+        PrecisionMoveRequest.model_validate(_base_body(speed_m_s=bad))
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), "nan"])
+def test_precision_move_rejects_nonfinite_yaw_degrees(bad):
+    with pytest.raises((ValidationError, ValueError)):
+        PrecisionMoveRequest.model_validate(
+            _base_body(
+                translation_m={"forward": 0.0, "right": 0.0, "up": 0.0},
+                yaw={"mode": "absolute_heading", "degrees": bad},
+            )
+        )
+
+
+def test_precision_move_happy_yaw_absolute():
+    req = PrecisionMoveRequest.model_validate(
+        _base_body(
+            translation_m={"forward": 0.0, "right": 0.0, "up": 0.0},
+            yaw={"mode": "absolute_heading", "degrees": 90.0},
+        )
+    )
+    assert req.yaw.degrees == pytest.approx(90.0)
+    assert math.isfinite(req.yaw.degrees)


### PR DESCRIPTION
## Summary

- Reject `nan`/`inf` in `PrecisionMoveRequest.translation_m` and `yaw.degrees`
- Disallow non-finite values on optional speed/tolerance/timeout fields (`allow_inf_nan=False`)
- Prevents offboard precision-move from inheriting IEEE-poisoned contract payloads

## Motivation

Translation components were parsed with bare `float(...)` and timing fields use `gt=0`, which still accepts `+inf` under pydantic 2.x. Non-finite targets can poison local NED setpoints. Fail closed at the shared command contract.

## Verification

- `python3 -m pytest tests/test_command_contract_precision_move_finite.py -o addopts= --noconftest` — 13 passed
- Did NOT change: geofence, arming logic, or precision-move runner control loops

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h