### PR TITLE
fix: fail closed on non-finite mission startup health timeouts

### DIFF
--- a/src/mission_startup.py
+++ b/src/mission_startup.py
@@ -18,6 +18,29 @@ from src.action_safety import (
 from src.params import Params
 
 
+
+def _positive_finite_float(value, default: float) -> float:
+    """Return value when it is a finite float > 0; otherwise return default."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if math.isfinite(parsed) and parsed > 0.0:
+        return parsed
+    return float(default)
+
+
+def _non_negative_finite_float(value, default: float) -> float:
+    """Return value when it is a finite float >= 0; otherwise return default."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if math.isfinite(parsed) and parsed >= 0.0:
+        return parsed
+    return float(default)
+
+
 _DEFAULT_LAUNCH_BATTERY_MIN_REMAINING_PERCENT = 30.0
 _STATUS_TEXT_MAX_ITEMS = 8
 _STATUS_TEXT_MAX_CHARS = 240
@@ -391,9 +414,18 @@ async def probe_offboard_armability(
     share the same armability definition.
     """
     logger = logger or logging.getLogger(__name__)
-    wait_timeout = float(timeout or getattr(Params, "OFFBOARD_ARM_HEALTH_TIMEOUT_SEC", 15.0))
-    sample_timeout = float(getattr(Params, "OFFBOARD_ARM_HEALTH_POLL_SEC", 0.5))
-    stable_samples = max(1, int(getattr(Params, "OFFBOARD_ARM_HEALTH_STABLE_SAMPLES", 1)))
+    wait_timeout = _positive_finite_float(
+        timeout or getattr(Params, "OFFBOARD_ARM_HEALTH_TIMEOUT_SEC", 15.0),
+        15.0,
+    )
+    sample_timeout = _positive_finite_float(
+        getattr(Params, "OFFBOARD_ARM_HEALTH_POLL_SEC", 0.5),
+        0.5,
+    )
+    try:
+        stable_samples = max(1, int(getattr(Params, "OFFBOARD_ARM_HEALTH_STABLE_SAMPLES", 1)))
+    except (TypeError, ValueError):
+        stable_samples = 1
     minimum_battery_percent = _launch_battery_minimum_percent(logger)
 
     deadline = time.monotonic() + wait_timeout
@@ -533,9 +565,21 @@ async def arm_with_preflight_gate(
     Wait for armability, then arm with bounded retries on transient denials.
     """
     logger = logger or logging.getLogger(__name__)
-    max_attempts = max(1, int(getattr(Params, "OFFBOARD_ARM_MAX_ATTEMPTS", 3)))
-    retry_delay = float(getattr(Params, "OFFBOARD_ARM_RETRY_DELAY_SEC", 2.0))
-    arm_action_timeout = max(1.0, float(getattr(Params, "OFFBOARD_ARM_ACTION_TIMEOUT_SEC", 15.0)))
+    try:
+        max_attempts = max(1, int(getattr(Params, "OFFBOARD_ARM_MAX_ATTEMPTS", 3)))
+    except (TypeError, ValueError):
+        max_attempts = 3
+    retry_delay = _non_negative_finite_float(
+        getattr(Params, "OFFBOARD_ARM_RETRY_DELAY_SEC", 2.0),
+        2.0,
+    )
+    arm_action_timeout = max(
+        1.0,
+        _positive_finite_float(
+            getattr(Params, "OFFBOARD_ARM_ACTION_TIMEOUT_SEC", 15.0),
+            15.0,
+        ),
+    )
 
     status_text_ring = deque(maxlen=_STATUS_TEXT_MAX_ITEMS)
     denial_evidence = deque(maxlen=_STATUS_TEXT_MAX_ITEMS)

--- a/tests/test_mission_startup.py
+++ b/tests/test_mission_startup.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import sys
 import types
 from types import SimpleNamespace
@@ -484,3 +485,92 @@ async def test_non_denial_action_error_preserves_mavsdk_error(monkeypatch):
             drone,
             require_global_position=True,
         )
+
+
+def test_positive_finite_float_helper_rejects_nonfinite():
+    assert mission_startup._positive_finite_float(float("nan"), 15.0) == 15.0
+    assert mission_startup._positive_finite_float(float("inf"), 15.0) == 15.0
+    assert mission_startup._positive_finite_float(-1.0, 15.0) == 15.0
+    assert mission_startup._positive_finite_float("nope", 15.0) == 15.0
+    assert mission_startup._positive_finite_float(3.5, 15.0) == 3.5
+
+
+def test_non_negative_finite_float_helper_allows_zero():
+    assert mission_startup._non_negative_finite_float(0.0, 2.0) == 0.0
+    assert mission_startup._non_negative_finite_float(float("nan"), 2.0) == 2.0
+    assert mission_startup._non_negative_finite_float(float("-inf"), 2.0) == 2.0
+
+
+def test_probe_offboard_armability_falls_back_from_nonfinite_timeout(monkeypatch):
+    async def _stuck_stream():
+        while True:
+            yield SimpleNamespace(
+                is_armable=False,
+                is_global_position_ok=False,
+                is_home_position_ok=False,
+                is_local_position_ok=False,
+                is_gyrometer_calibration_ok=False,
+                is_accelerometer_calibration_ok=False,
+                is_magnetometer_calibration_ok=False,
+            )
+
+    drone = MagicMock()
+    drone.telemetry.health = _stuck_stream
+    # battery stream may be required by current probe path
+    async def _battery_stream():
+        while True:
+            yield SimpleNamespace(remaining_percent=100.0)
+
+    drone.telemetry.battery = _battery_stream
+    monkeypatch.setattr(mission_startup.Params, "OFFBOARD_ARM_HEALTH_TIMEOUT_SEC", float("inf"))
+    monkeypatch.setattr(mission_startup.Params, "OFFBOARD_ARM_HEALTH_POLL_SEC", float("nan"))
+
+    original = mission_startup._positive_finite_float
+
+    def _fast_default(value, default):
+        result = original(value, default)
+        try:
+            parsed = float(value)
+            bad = not (math.isfinite(parsed) and parsed > 0)
+        except (TypeError, ValueError):
+            bad = True
+        if bad:
+            return 0.05 if float(default) >= 1.0 else 0.01
+        return result
+
+    monkeypatch.setattr(mission_startup, "_positive_finite_float", _fast_default)
+
+    result = asyncio.run(
+        mission_startup.probe_offboard_armability(
+            drone,
+            require_global_position=True,
+        )
+    )
+    assert result["timed_out"] is True
+    assert result["ready"] is False
+
+
+def test_arm_with_preflight_gate_uses_finite_arm_timeout_budget(monkeypatch):
+    drone = MagicMock()
+    drone.action.arm = AsyncMock(return_value=None)
+    async def _status_text_stream():
+        await asyncio.Event().wait()
+        yield  # pragma: no cover
+
+    drone.telemetry.status_text = _status_text_stream
+    wait_mock = AsyncMock(return_value={"ready": True, "observation": {}})
+    monkeypatch.setattr(mission_startup, "wait_until_offboard_armable", wait_mock)
+    monkeypatch.setattr(mission_startup.Params, "OFFBOARD_ARM_MAX_ATTEMPTS", 1)
+    monkeypatch.setattr(mission_startup.Params, "OFFBOARD_ARM_RETRY_DELAY_SEC", float("nan"))
+    monkeypatch.setattr(mission_startup.Params, "OFFBOARD_ARM_ACTION_TIMEOUT_SEC", float("inf"))
+    captured = {}
+    real_wait_for = asyncio.wait_for
+
+    async def _capture(awaitable, timeout):
+        captured["timeout"] = timeout
+        return await real_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr(mission_startup.asyncio, "wait_for", _capture)
+    asyncio.run(mission_startup.arm_with_preflight_gate(drone, require_global_position=True))
+    assert math.isfinite(captured["timeout"])
+    assert captured["timeout"] >= 1.0


### PR DESCRIPTION
## Summary

- Sanitize mission-startup health wait/poll samples, arm retry delay, and arm action timeout via finite-float helpers
- Non-finite `Params` overrides fall back to documented defaults instead of eternal waits or `nan` budgets
- Does not change arming gate criteria — timeout budgeting only

## Motivation

`probe_offboard_armability` / `arm_with_preflight_gate` used bare `float(...)` on timeout Params. `+inf` never expires the wait budget; `nan` breaks deadline math and `asyncio.wait_for` timeout values. Fail closed on non-finite budgets.

## Verification

- `python3 -m pytest tests/test_mission_startup.py -o addopts= --noconftest -k "finite or non_negative or falls_back or uses_finite"` — 4 passed
- Did NOT change: geofence, armability readiness criteria, or flight maneuver paths

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h