### PR TITLE
fix: reject non-finite telemetry update times and stale thresholds

### DIFF
--- a/src/drone_communicator.py
+++ b/src/drone_communicator.py
@@ -232,7 +232,8 @@ class DroneCommunicator:
         except (TypeError, ValueError):
             return 0
 
-        if numeric_value <= 0:
+        # Non-finite values would raise ValueError/OverflowError at int(); treat as unknown.
+        if not math.isfinite(numeric_value) or numeric_value <= 0:
             return 0
 
         if numeric_value < 1_000_000_000_000:
@@ -253,7 +254,11 @@ class DroneCommunicator:
         except (TypeError, ValueError):
             configured_timeout_value = None
 
-        if configured_timeout_value is None or configured_timeout_value <= 0:
+        if (
+            configured_timeout_value is None
+            or not math.isfinite(configured_timeout_value)
+            or configured_timeout_value <= 0
+        ):
             configured_timeout = (
                 _coerce_positive_int(getattr(self.params, 'LOCAL_MAVLINK_TIMEOUT_SEC', 5), 5)
                 * _coerce_positive_int(getattr(self.params, 'LOCAL_MAVLINK_RECONNECT_AFTER_TIMEOUTS', 3), 3)

--- a/tests/test_drone_communicator_finite_timestamps.py
+++ b/tests/test_drone_communicator_finite_timestamps.py
@@ -1,0 +1,57 @@
+"""Fail-closed finite checks on DroneCommunicator timestamp helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.drone_communicator import DroneCommunicator
+
+
+def _communicator_with_params(**params) -> DroneCommunicator:
+    drone_config = SimpleNamespace(
+        hw_id=1,
+        pos_id=1,
+        config={"ip": "127.0.0.1", "mavlink_port": 14540},
+    )
+    base = {
+        "enable_udp_telemetry": False,
+        "enable_default_subscriptions": False,
+        "LOCAL_MAVLINK_TIMEOUT_SEC": 5,
+        "LOCAL_MAVLINK_RECONNECT_AFTER_TIMEOUTS": 3,
+    }
+    base.update(params)
+    return DroneCommunicator(
+        drone_config=drone_config,
+        params=SimpleNamespace(**base),
+        drones={},
+    )
+
+
+def test_normalize_update_time_ms_rejects_non_finite():
+    assert DroneCommunicator._normalize_update_time_ms(float("nan")) == 0
+    assert DroneCommunicator._normalize_update_time_ms(float("inf")) == 0
+    assert DroneCommunicator._normalize_update_time_ms(float("-inf")) == 0
+    assert DroneCommunicator._normalize_update_time_ms("nan") == 0
+    assert DroneCommunicator._normalize_update_time_ms("inf") == 0
+
+
+def test_normalize_update_time_ms_happy_paths():
+    # Seconds-scale timestamp scaled to ms
+    assert DroneCommunicator._normalize_update_time_ms(1_700_000_000) == 1_700_000_000_000
+    # Already-ms timestamp left alone
+    assert DroneCommunicator._normalize_update_time_ms(1_700_000_000_000) == 1_700_000_000_000
+    assert DroneCommunicator._normalize_update_time_ms(0) == 0
+    assert DroneCommunicator._normalize_update_time_ms(-5) == 0
+    assert DroneCommunicator._normalize_update_time_ms(None) == 0
+    assert DroneCommunicator._normalize_update_time_ms("bogus") == 0
+
+
+def test_local_mavlink_stale_threshold_rejects_non_finite_override():
+    # Finite override wins
+    comm = _communicator_with_params(LOCAL_MAVLINK_STALE_TIMEOUT_SEC=2.5)
+    assert comm._local_mavlink_stale_threshold_ms() == 2500
+
+    # Non-finite override falls back to timeout * reconnect (5 * 3 = 15s → 15000 ms)
+    for poisoned in (float("nan"), float("inf"), float("-inf"), "nan", "inf"):
+        comm = _communicator_with_params(LOCAL_MAVLINK_STALE_TIMEOUT_SEC=poisoned)
+        assert comm._local_mavlink_stale_threshold_ms() == 15_000


### PR DESCRIPTION
## Summary

- Require `math.isfinite` in `DroneCommunicator._normalize_update_time_ms` before the seconds→ms heuristic and `int()` cast; non-finite → `0` (same as invalid).
- Treat non-finite `LOCAL_MAVLINK_STALE_TIMEOUT_SEC` as missing so the existing timeout×reconnect fallback applies instead of raising.

## Motivation

`float("nan")` / `float("inf")` are not `<= 0`, so they previously reached `int(nan)` (`ValueError`) or `int(inf)` (`OverflowError`) on the telemetry path. Poisoned timestamps should fail closed to “unknown” rather than unwind communicator helpers used for stale MAVLink blockers.

## Verification

```bash
PYTHONPATH=.:src python3 -m pytest tests/test_drone_communicator_finite_timestamps.py -o addopts= --noconftest -q
# 3 passed
```

Did NOT change: arming, geofence, altitude limits, or flight control loops.

Human-reviewed; AI-assisted drafting.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
