### PR TITLE
fix: reject non-finite agent assistant env float overrides

### DIFF
--- a/gcs-server/agent_runtime/assistant.py
+++ b/gcs-server/agent_runtime/assistant.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import math
 import os
 import re
 import stat
@@ -223,9 +224,13 @@ def _env_float(name: str, default: float) -> float:
     if raw in (None, ""):
         return default
     try:
-        return float(raw)
+        value = float(raw)
     except ValueError as exc:
         raise AgentRuntimeError(f"{name} must be a number") from exc
+    # pydantic-style gt/bounds still accept +inf; hangable timeouts must be finite.
+    if not math.isfinite(value):
+        raise AgentRuntimeError(f"{name} must be a finite number")
+    return value
 
 
 def _env_bool(name: str, default: bool) -> bool:

--- a/tests/test_assistant_env_float_finite.py
+++ b/tests/test_assistant_env_float_finite.py
@@ -1,0 +1,37 @@
+"""Fail-closed finite checks on assistant env float overrides."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_runtime.assistant import _env_float
+from agent_runtime.models import AgentRuntimeError
+
+
+def test_env_float_missing_returns_default(monkeypatch):
+    monkeypatch.delenv("MDS_TEST_ENV_FLOAT", raising=False)
+    assert _env_float("MDS_TEST_ENV_FLOAT", 3.5) == 3.5
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "")
+    assert _env_float("MDS_TEST_ENV_FLOAT", 3.5) == 3.5
+
+
+def test_env_float_parses_finite(monkeypatch):
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "1.5")
+    assert _env_float("MDS_TEST_ENV_FLOAT", 0.0) == 1.5
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "0")
+    assert _env_float("MDS_TEST_ENV_FLOAT", 9.0) == 0.0
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "-2.25")
+    assert _env_float("MDS_TEST_ENV_FLOAT", 0.0) == -2.25
+
+
+def test_env_float_rejects_non_finite(monkeypatch):
+    for poisoned in ("nan", "NaN", "inf", "+inf", "-inf", "Infinity"):
+        monkeypatch.setenv("MDS_TEST_ENV_FLOAT", poisoned)
+        with pytest.raises(AgentRuntimeError, match="finite"):
+            _env_float("MDS_TEST_ENV_FLOAT", 1.0)
+
+
+def test_env_float_rejects_non_numeric(monkeypatch):
+    monkeypatch.setenv("MDS_TEST_ENV_FLOAT", "nope")
+    with pytest.raises(AgentRuntimeError, match="number"):
+        _env_float("MDS_TEST_ENV_FLOAT", 1.0)


### PR DESCRIPTION
## Summary

- `agent_runtime.assistant._env_float` now rejects IEEE non-finite env overrides with `AgentRuntimeError` after a successful `float()` parse.
- Empty/missing env still returns the provided default (unchanged).

## Motivation

Operator env knobs (notably OpenAI `timeout_seconds`) used bare `float(raw)`. `inf`/`nan` pass Python's float parser and can hang provider waits or break comparisons. Loud fail-closed at config load is safer than silent infinity.

## Verification

```bash
PYTHONPATH=gcs-server:.:src python3 -m pytest tests/test_assistant_env_float_finite.py -o addopts= --noconftest -q
# 4 passed
```

Did NOT change: YAML assistant config loading, tool registry, arming/geofence paths.

Human-reviewed; AI-assisted drafting.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
