### PR TITLE
fix: fail closed on non-finite local relative altitude snapshots

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -47,6 +47,7 @@ This script executes various drone actions using MAVSDK:
 ---------------------------------------------------------------
 """
 
+import math
 import argparse
 import asyncio
 import csv
@@ -445,7 +446,14 @@ def _get_local_relative_altitude_snapshot(timeout: float = 1.0):
     except (TypeError, ValueError):
         return None
 
-    return current_altitude - home_altitude
+    # Fail closed: NaN/inf altitudes must not poison takeoff/altitude confirms.
+    if not math.isfinite(current_altitude) or not math.isfinite(home_altitude):
+        return None
+
+    relative_altitude = current_altitude - home_altitude
+    if not math.isfinite(relative_altitude):
+        return None
+    return relative_altitude
 
 
 async def _get_current_relative_altitude(drone, timeout: float = 3.0):

--- a/tests/test_actions_local_rel_alt_finite.py
+++ b/tests/test_actions_local_rel_alt_finite.py
@@ -1,0 +1,97 @@
+"""Fail-closed local relative-altitude snapshot (non-finite telemetry)."""
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+sys.modules.setdefault("psutil", MagicMock())
+sys.modules.setdefault("requests", MagicMock())
+mavsdk_module = types.ModuleType("mavsdk")
+mavsdk_module.System = MagicMock()
+mavsdk_module.telemetry = MagicMock()
+mavsdk_module.action = MagicMock()
+mavsdk_module.__path__ = []
+sys.modules.setdefault("mavsdk", mavsdk_module)
+sys.modules.setdefault("mavsdk.system", types.SimpleNamespace(System=MagicMock()))
+offboard_module = types.ModuleType("mavsdk.offboard")
+for name in (
+    "PositionNedYaw",
+    "VelocityBodyYawspeed",
+    "PositionGlobalYaw",
+    "VelocityNedYaw",
+    "AccelerationNed",
+):
+    setattr(offboard_module, name, MagicMock())
+offboard_module.OffboardError = type("OffboardError", (Exception,), {})
+sys.modules.setdefault("mavsdk.offboard", offboard_module)
+telemetry_module = types.ModuleType("mavsdk.telemetry")
+telemetry_module.FlightMode = types.SimpleNamespace(HOLD=types.SimpleNamespace(name="HOLD"))
+telemetry_module.LandedState = types.SimpleNamespace(LANDING="LANDING", ON_GROUND="ON_GROUND")
+sys.modules.setdefault("mavsdk.telemetry", telemetry_module)
+sys.modules.setdefault(
+    "mavsdk.action", types.SimpleNamespace(ActionError=type("ActionError", (Exception,), {}))
+)
+
+# Stub heavy local packages often pulled by actions import chain
+for mod_name in (
+    "src.led_controller",
+    "src.drone_config",
+    "navpy",
+    "pyproj",
+):
+    sys.modules.setdefault(mod_name, MagicMock())
+
+import actions  # noqa: E402
+
+
+def test_local_rel_alt_happy_path(monkeypatch):
+    monkeypatch.setattr(
+        actions,
+        "_get_local_drone_state_snapshot",
+        lambda timeout=1.0: {"position_alt": 120.5},
+    )
+    monkeypatch.setattr(
+        actions,
+        "_get_local_home_position_snapshot",
+        lambda timeout=1.0: {"altitude": 100.0},
+    )
+    assert actions._get_local_relative_altitude_snapshot() == pytest.approx(20.5)
+
+
+@pytest.mark.parametrize(
+    "pos_alt, home_alt",
+    [
+        (float("nan"), 100.0),
+        (120.0, float("nan")),
+        (float("inf"), 100.0),
+        (120.0, float("-inf")),
+        ("nan", 100.0),
+        (None, 100.0),
+        (120.0, None),
+        ("nope", 100.0),
+    ],
+)
+def test_local_rel_alt_rejects_bad(monkeypatch, pos_alt, home_alt):
+    monkeypatch.setattr(
+        actions,
+        "_get_local_drone_state_snapshot",
+        lambda timeout=1.0: {"position_alt": pos_alt},
+    )
+    monkeypatch.setattr(
+        actions,
+        "_get_local_home_position_snapshot",
+        lambda timeout=1.0: {"altitude": home_alt},
+    )
+    assert actions._get_local_relative_altitude_snapshot() is None
+
+
+def test_local_rel_alt_missing_snapshots(monkeypatch):
+    monkeypatch.setattr(actions, "_get_local_drone_state_snapshot", lambda timeout=1.0: None)
+    monkeypatch.setattr(
+        actions, "_get_local_home_position_snapshot", lambda timeout=1.0: {"altitude": 1.0}
+    )
+    assert actions._get_local_relative_altitude_snapshot() is None


### PR DESCRIPTION
## Summary
Local drone API altitude snapshots can surface IEEE NaN/inf. Before those values drive takeoff or altitude confirmation, treat non-finite `position_alt` / home altitude (or a non-finite difference) as **unknown** and return `None`.

## Changes
- `actions._get_local_relative_altitude_snapshot`: require `math.isfinite` on both legs and the relative result
- Tests: happy path + nan/inf/null/invalid matrix (10 cases)

## Test plan
- [x] `python3 -m pytest tests/test_actions_local_rel_alt_finite.py -o addopts= --noconftest`

## Notes
- Minimal fail-closed telemetry hygiene; no geofence/arm path relaxes
- AI-assisted; human-reviewed


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->